### PR TITLE
Fix crash: If active index became higher than number of clips.

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -46,6 +46,16 @@ class App extends PureComponent {
         this.updatePlayingStatus = this.updatePlayingStatus.bind(this);
     }
 
+    static getDerivedStateFromError(error) {
+        // Update state so the next render will show the fallback UI.
+        return { hasError: true };
+    }
+
+    componentDidCatch(error, info) {
+        // You can also log the error to an error reporting service
+        logErrorToMyService(error, info);
+    }
+
     componentWillMount() {
         //Setup Keyboard shortcuts:
         document.addEventListener("keydown", this._handleKeyDown.bind(this));

--- a/src/reducers/dataReducer.js
+++ b/src/reducers/dataReducer.js
@@ -67,6 +67,13 @@ export const dataReducer = ((state = defaultDataReducerState, action) => {
         case 'SET_THUMB_LENGTH':
             if (action.data.length < nextState[0].data.channel[action.data.tab].thumbList.length) {
                 nextState[0].data.channel[action.data.tab].thumbList.length = action.data.length;
+                // Check if active thumb is out of range of new thumblist.
+                if (nextState[0].data.channel[action.data.tab].thumbActiveIndex > (action.data.length - 1)) {
+                    nextState[0].data.channel[action.data.tab].thumbActiveIndex = action.data.length - 1;
+                }
+                if (nextState[0].data.channel[action.data.tab].thumbActiveBgIndex > (action.data.length-1)) {
+                    nextState[0].data.channel[action.data.tab].thumbActiveBgIndex = action.data.length - 1;
+                }
             }
             return nextState;
         case 'SET_THUMB_LIST':


### PR DESCRIPTION
When removing mediafiles on the CCG-server, it could happen that the active index became higher than number of clips, and then crashed the app.