### PR TITLE
Fix: Autonext didn´t restart when media was stopped

### DIFF
--- a/mainBundler.js
+++ b/mainBundler.js
@@ -1,2 +1,0 @@
-require('@babel/register');
-require('./main.js');

--- a/package.json
+++ b/package.json
@@ -36,9 +36,6 @@
     "package-rpi": "electron-packager . casparcg-cliptool --overwrite --asar=true --platform=linux --arch=armv7l --icon=assets/icons/png/1024x1024.png --prune=true --out=release-builds"
   },
   "dependencies": {
-    "@babel/core": "^7.3.3",
-    "@babel/plugin-proposal-object-rest-spread": "^7.3.2",
-    "@babel/register": "^7.0.0",
     "apollo-cache-inmemory": "^1.3.9",
     "apollo-client": "^2.4.5",
     "apollo-link-http": "^1.5.5",
@@ -58,6 +55,9 @@
     "subscriptions-transport-ws": "^0.9.15"
   },
   "devDependencies": {
+    "@babel/core": "^7.3.3",
+    "@babel/plugin-proposal-object-rest-spread": "^7.3.2",
+    "@babel/register": "^7.0.0",
     "@babel/preset-env": "^7.2.3",
     "@babel/preset-react": "^7.0.0",
     "babel-loader": "^8.0.4",

--- a/src/reducers/dataReducer.js
+++ b/src/reducers/dataReducer.js
@@ -41,7 +41,7 @@ const defaultDataReducerState = () => {
     return stateDefault;
 };
 
-let lastTimeCounter = 0;
+let lastTimeCounter = [0, 0, 0, 0];
 
 export const data = ((state = defaultDataReducerState(), action) => {
 
@@ -62,9 +62,9 @@ export const data = ((state = defaultDataReducerState(), action) => {
                 //ToDo: paused should be correct from CCG statescanner,
                 //but it does not show correctly with CCG 2.1.3
                 nextState[0].ccgInfo[index].layers[9].foreground.paused = (state[0].ccgTime[index] === item.time) && (state[0].ccgPrevTime[index] === item.time);
-                if (lastTimeCounter++ === 5) {
+                if (lastTimeCounter[index]++ === 5) {
                     nextState[0].ccgPrevTime[index] = state[0].ccgTime[index];
-                    lastTimeCounter = 0;
+                    lastTimeCounter[index] = 0;
                 }
 
                 nextState[0].ccgTimeLeft[index] = item.timeLeft;


### PR DESCRIPTION
Fix: Autonext didn´trestart when stopped (randomly) - lastTimeCounter was shared among all channels. Now an array