### PR TITLE
Ut 133/ignore alpha files in media browser

### DIFF
--- a/src/client/components/App.tsx
+++ b/src/client/components/App.tsx
@@ -36,6 +36,7 @@ export const App = () => {
             <div className="App">
                 <RenderFullHeader />
                 <div className="App-body">
+                    { /* @ts-ignore */}
                     <Tabs
                         tabs={reduxState.settings[0].tabData}
                         onChange={(tab, index) => setOutput(index)}

--- a/src/server/handlers/CasparCgHandler.ts
+++ b/src/server/handlers/CasparCgHandler.ts
@@ -218,10 +218,12 @@ async function loadFileList() {
             reduxState.media[0].output.forEach(
                 (output: IOutput, channelIndex: number) => {
                     let outputMedia = payload.response.data.filter((file) => {
-                        return file.name.includes(
-                            reduxState.settings[0].generics.outputFolders[
-                                channelIndex
-                            ]
+                        return (
+                            file.name.includes(
+                                reduxState.settings[0].generics.outputFolders[
+                                    channelIndex
+                                ]
+                            ) && !isAlphaFile(file.name)
                         )
                     })
                     if (
@@ -244,6 +246,10 @@ async function loadFileList() {
         .catch((error) => {
             console.log('Error receiving file list :', error)
         })
+}
+
+function isAlphaFile(filename: string): boolean {
+    return /_a(\.[a-zæøå0-9]+)?$/i.test(filename)
 }
 
 async function loadThumbNailImage(element: IThumbFile) {

--- a/src/server/handlers/CasparCgHandler.ts
+++ b/src/server/handlers/CasparCgHandler.ts
@@ -249,7 +249,7 @@ async function loadFileList() {
 }
 
 function isAlphaFile(filename: string): boolean {
-    return /_a(\.[a-zæøå0-9]+)?$/i.test(filename)
+    return /_a(\.[^.]+)?$/i.test(filename)
 }
 
 async function loadThumbNailImage(element: IThumbFile) {


### PR DESCRIPTION
Filters out `_A` (alpha) files from the file overview.