### PR TITLE
fix: Use fill file for marking tally.

### DIFF
--- a/src/server/handlers/CasparCgHandler.ts
+++ b/src/server/handlers/CasparCgHandler.ts
@@ -55,7 +55,10 @@ const setupOscServer = () => {
             let channelIndex = findChannelNumber(message.address) - 1
             let layerIndex = findLayerNumber(message.address) - 1
             if (message.address.includes('/stage/layer')) {
-                if (message.address.includes('file/path')) {
+                if (
+                    message.address.includes('file/path') &&
+                    !message.address.includes('keyer')
+                ) {
                     if (layerIndex === 9) {
                         let fileName = message.args[0]
                         if (


### PR DESCRIPTION
Because alpha files no longer are displayed, but are still reported via OSC as being in program, no tally was displayed.